### PR TITLE
add support for xyz files with scientific notation

### DIFF
--- a/calculate_rmsd
+++ b/calculate_rmsd
@@ -178,7 +178,7 @@ def get_coordinates(filename, ignore_hydrogens=False):
             break
 
         atom = re.findall(r'[a-zA-Z]+', line)[0]
-        numbers = re.findall(r'[-]?\d+\.\d*', line)
+        numbers = re.findall(r'[-]?\d+\.\d*(?:[Ee][-\+]\d+)?', line)
         numbers = [float(number) for number in numbers]
 
         # ignore hydrogens


### PR DESCRIPTION
python's float('1.12552e+01') can handle the scientific notation, but the regex did not match the exponents.