### PR TITLE
Fixed small bug and added features

### DIFF
--- a/calculate_rmsd
+++ b/calculate_rmsd
@@ -191,17 +191,27 @@ def get_coordinates_pdb(filename, ignore_hydrogens):
     # Same with atoms and atom naming. The most robust way to do this is probably
     # to assume that the atomtype is given in column 3.
     atoms = []
+    count=0
+
+    # giving idx list rules out ignore_hydrogens
+    if args.remove_idx or args.add_idx: ignore_hydrogens=False
+
     with open(filename) as f:
         lines = f.readlines()
         for line in lines:
             if line.startswith("TER") or line.startswith("END"):
                 break
             if line.startswith("ATOM"):
+                count+=1
                 tokens = line.split()
                 # Try to get the atomtype
                 try:
                     atom = tokens[2][0]
-                    if ignore_hydrogens and atom == "H":
+                    if args.remove_idx and count in args.remove_idx:
+                       continue
+                    elif args.add_idx and count not in args.add_idx:
+                       continue
+                    elif ignore_hydrogens and atom == "H":
                         continue
                     elif atom in ["H", "C", "N", "O", "S", "P"]:
                         atoms.append(atom)
@@ -259,18 +269,26 @@ def get_coordinates_xyz(filename, ignore_hydrogens):
     # Skip the title line
     f.next()
 
+    # giving idx list rules out ignore_hydrogens
+    if args.remove_idx or args.add_idx: ignore_hydrogens=False
+
     # Use the number of atoms to not read beyond the end of a file
     for line in f:
 
         if lines_read == n_atoms:
             break
+        lines_read += 1
 
         atom = re.findall(r'[a-zA-Z]+', line)[0]
         numbers = re.findall(r'[-]?\d+\.\d*(?:[Ee][-\+]\d+)?', line)
         numbers = [float(number) for number in numbers]
 
-        # ignore hydrogens
-        if ignore_hydrogens and atom.lower() == "h":
+        # ignore hydrogens or selected idx atoms
+        if args.remove_idx and lines_read in args.remove_idx:
+            continue
+        elif args.add_idx and lines_read not in args.add_idx:
+            continue
+        elif ignore_hydrogens and atom.lower() == "h":
             continue
 
         # The numbers are not valid unless we obtain exacly three
@@ -280,7 +298,6 @@ def get_coordinates_xyz(filename, ignore_hydrogens):
         else:
             exit("Reading the .xyz file failed in line {0}. Please check the format.".format(lines_read + 2))
 
-        lines_read += 1
 
     f.close()
     V = np.array(V)
@@ -330,6 +347,8 @@ Quater: RMSD after coordinates are translated and rotated using quaternions.
     parser.add_argument('-o', '--output', action='store_true', help='print out structure A, centered and rotated unto structure B\'s coordinates in XYZ format')
     parser.add_argument('-n', '--no-hydrogen', action='store_true', help='ignore hydrogens when calculating RMSD')
     parser.add_argument('-f', '--format', action='store', help='Format of input files. Supports xyz or pdb.')
+    parser.add_argument('-r','--remove-idx', nargs='+', type=int, help='index list of atoms NOT to consider')
+    parser.add_argument('-a','--add-idx', nargs='+', type=int, help='index list of atoms to consider')
 
     if len(sys.argv) == 1:
         parser.print_help()
@@ -359,6 +378,20 @@ Quater: RMSD after coordinates are translated and rotated using quaternions.
         V = rotate(P, Q)
         V += Qc
         write_coordinates(atomsP, V)
+
+
+        if args.no_hydrogen or args.add_idx or args.remove_idx:
+           U = kabsch(P, Q)
+           args.remove_idx=False
+           args.add_idx=False
+           atomsP2, P2 = get_coordinates(args.structure_a, args.format, False)
+           P2 -= Pc
+
+           # Rotate P2
+           P2 = np.dot(P2, U)
+           print('\n--------------- Full structure-a --------------')
+           write_coordinates(atomsP2, P2+Qc)
+
         quit()
 
     print "Normal RMSD:", normal_rmsd


### PR DESCRIPTION
fixed bug on line 283 where lines_read is not updated if ignore_hydrogens is set

Added two new flags to add (-a, --add-idx) or remove (-r, --remove-idx) specific atoms by their index from the supplied structures files before calculation.

Added extra output of the rotated structure_A for all the atoms if only a subset has been used due to -n, -a or -r flags.

Example output:
```
./calculate_rmsd.py CarbamicAcid.xyz NH3CO2.xyz -o -r 3 4 7
4

N      -0.02131277     -1.02005059      0.11750640
C       0.07064874      0.34038055     -0.05473715
O       1.11230161      0.94210408     -0.13936910
O      -1.12545299      0.99773510     -0.12749467

--------------- Full structure-a --------------
7

N      -0.02131277     -1.02005059      0.11750640
C       0.07064874      0.34038055     -0.05473715
H       0.84719878     -1.53437214      0.17500095
H      -0.88958851     -1.53098743      0.18923242
O       1.11230161      0.94210408     -0.13936910
O      -1.12545299      0.99773510     -0.12749467
H      -1.86629068      0.37921256     -0.04328419

```

```
./calculate_rmsd.py CarbamicAcid.xyz NH3CO2.xyz -o -a 3 4 7
3

H       0.97006042     -2.42007901     -0.97390867
H      -0.56949261     -2.29634025     -0.17948480
H      -0.54737672     -2.05019135      1.96429614

--------------- Full structure-a --------------
7

N       0.43869778     -2.31077081     -0.12076738
C       1.15328702     -2.19143373      1.04714466
H       0.97006042     -2.42007901     -0.97390867
H      -0.56949261     -2.29634025     -0.17948480
O       2.35756422     -2.20978547      1.10759375
O       0.39779024     -2.04561121      2.17675894
H      -0.54737672     -2.05019135      1.96429614
```
