### PR TITLE
A new option which keeps stereochemistry.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,3 +127,10 @@ Problems?
 ---------
 
 Submit issues or pull requests on GitHub.
+
+
+Known Problems:
+---------
+- **Performance of Hungarian Algorithm in Scipy**:
+    Scipy.optimize.linear_sum_assignment is a slow implementation of hungarian algorithm. Try my implementation https://github.com/xg590/munkres or other's https://github.com/hrldcpr/hungarian.
+

--- a/README.rst
+++ b/README.rst
@@ -132,5 +132,5 @@ Submit issues or pull requests on GitHub.
 Known Problems:
 ---------
 - **Performance of Hungarian Algorithm in Scipy**:
-    Scipy.optimize.linear_sum_assignment is a slow implementation of hungarian algorithm. Try my implementation https://github.com/xg590/munkres or other's https://github.com/hrldcpr/hungarian.
+    scipy.optimize.linear_sum_assignment is a slow implementation of hungarian algorithm. Try my implementation https://github.com/xg590/munkres or other's https://github.com/hrldcpr/hungarian.
 

--- a/rmsd/calculate_rmsd.py
+++ b/rmsd/calculate_rmsd.py
@@ -526,7 +526,7 @@ def check_reflections(p_atoms, q_atoms, p_coord, q_coord,
     min_reflection = None
     min_review = None
     tmp_review = None
-    swap_mask = [1,-1,-1,1,1,-1]
+    swap_mask = [1,-1,-1,1,-1,1]
     reflection_mask = [1,-1,-1,-1,1,1,1,-1]
 
     for swap, i in zip(AXIS_SWAPS, swap_mask):

--- a/tests.py
+++ b/tests.py
@@ -369,6 +369,28 @@ class TestRMSD(unittest.TestCase):
 
         assert np.isclose(min_rmsd, 0.0, atol=1e-6)
 
+    def test_reflections_keep_stereo(self):
+
+        atoms = np.array(["C", "H", "H", "H", "F"])
+
+        p_coord = np.array(
+            [[-0.000000,  -0.000000,  -0.000000],
+            [  1.109398,  -0.000000,   0.000000],
+            [ -0.3697920, -0.7362220, -0.7429600],
+            [ -0.3698020,  1.011538,  -0.2661100],
+            [ -0.3698020, -0.2753120,  1.009070]])
+        q_coord = copy.deepcopy(p_coord)
+        q_coord[:,[0, 2]] = q_coord[:,[2, 0]] # swap [2,1,0]: prepare enantiomer coordinates (which is named as q_coord) of p_coord
+
+        # If keep_stereo is off, enantiomer coordinates of q_coord are considered, resulting into identical coordinates of p_coord.
+        min_rmsd, min_swap, min_reflection, min_review = self.check_reflections(atoms, atoms, p_coord, q_coord,
+                                                                                reorder_method=None, keep_stereo=False)
+        assert np.isclose(min_rmsd, 0.0, atol=1e-6) # the enantiomer of the enantiomer of the original molecule has zero RMSD with the original molecule.
+
+        # No enantiomer coordinates, non-zero RMSD.
+        min_rmsd, min_swap, min_reflection, min_review = self.check_reflections(atoms, atoms, p_coord, q_coord,
+                                                                                reorder_method=None, keep_stereo=True)
+        assert np.isclose(min_rmsd, 1.1457797, atol=1e-6)
 
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(TestRMSD)


### PR DESCRIPTION
Here is a jupyter notebook for the illustration: https://github.com/xg590/miscellaneous/blob/master/charnley_rmsd_proof.ipynb

Test the new option, which saves time because 24 enantiomers are skipped.
$ time (for i in {1..10} ;do python rmsd/calculate_rmsd.py tests/c6h7-int1-a.xyz tests/c6h7-int1-xz.xyz --use-reflections;done)
real    0m5.244s
user    0m4.879s
sys     0m0.341s

$ time (for i in {1..10} ;do python rmsd/calculate_rmsd.py tests/c6h7-int1-a.xyz tests/c6h7-int1-xz.xyz --use-reflections-keep-stereo;done)
real    0m4.376s
user    0m4.035s
sys     0m0.321s
