### PR TITLE
attempt exporting both *.xyz and (reflection based) RMSD

### DIFF
--- a/rmsd/calculate_rmsd.py
+++ b/rmsd/calculate_rmsd.py
@@ -1019,8 +1019,26 @@ https://github.com/charnley/rmsd for further examples.
         q_all += p_cent
 
         # done and done
-        xyz = set_coordinates(q_all_atoms, q_all, title="{} - modified".format(args.structure_b))
-        print(xyz)
+        # original output section, start
+        # xyz = set_coordinates(q_all_atoms, q_all, title="{} - modified".format(args.structure_b))
+        # print(xyz)
+        # original output section, end
+
+        # new output section for -p --use-reflections, start
+        # model data files read
+        fileA = sys.argv[1]
+        fileB = sys.argv[2]
+
+        fileNew = str(fileA)[:-4] + str("-testedWith-") + str(fileB)
+        titleNew = str(fileNew) + str(", new alignment of model B")
+        xyz = set_coordinates(q_all_atoms, q_all, titleNew)
+        with open(fileNew, mode="w") as newfile:
+            newfile.write(xyz)
+        print(str(fileA) + str(" was compared with ") + str(fileB))
+        print("reflection-based RMSD: {0}".format(result_rmsd))
+        print("Coordinates of newly aligned modelB:\n")
+        print(xyz, "\n")
+        # new output section for -p --use-reflections, end
 
     else:
 
@@ -1035,8 +1053,8 @@ https://github.com/charnley/rmsd for further examples.
 
         print("{0}".format(result_rmsd))
 
-
     return
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Scrutinizing multiple `*.xyz` files in a round-Robin tournament, each representing
a cluster of about a dozen identical constitutionally identical molecules, I sought
accessing both the newly aligned orientation of modelB as well as the corresponding
RMSD describing the goodness of fit for one and the same test performed.  Test data,
adapted moderator script, generated new alignment `*.xyz` and report obtained via

`python3 multipro.py > 20190328-RMSDandXYZ-test.txt`

on an instance of Linux Xubuntu 18.04.2 LTS (64 bit) with Python 3.6.7 are enclosed
in the attached zip.archive.

- As  expected, the `*.xzy` files written still are readable for either Jmol (14.6.2_2016.11.05),
or Avogadro (1.2.0).  Avogadro does not connect all atoms per molecule in the cluster
`*.xyz` data because originally the atom types intentionally were "unified" to one form --
here oxygen -- to permit any comparison by `calculate_rmsd.py`.

- There might be a better way to toggle between an output of "just RMSD" or "just the new
coordinates", on one hand, or "RMSD and new coordinates" as a new, third option.  So far,
my attempts to alter the parser-section (lines #811 and following) however failed to
accomplish this because I lack working experience with the corresponding module.  This is
why the original export instructions (`done and done`, lines #1021 following) are only
commented out.

- In difference to the earlier version of `calculate_rmsd.py`, a round-Robin tournament
testing of multiple `.xyz` no longer will systematically overwrite the newly written coordinate
file if the second structure file to test with happens to be the same.  As seen with kdiff3
(0.9.98) the coordinates in the piped CLI output nicely reappear in the separately written
`*.xyz` about the new alignemnt.  Due to the distributed computation on multiple CPU,
however, the order data input / launch of individual tests need not correspond to the
consecution of data output (reflection-based RMSD) on the CLI.  This is why the output
of "which files were tested" and their RMSD was reorganized.

- While the RMSD exported with `--use-reflections` in a manual test of a modelA and a
modelB appear again in the present batchwise test engaging `--use-reflections -p` with
the last print instruction of
`print("{0}.format(result_rmsd))`
(old line #1036), it seems to me that the other rmsd (`result_rmsd = rmsd(p_coord, q_coord)`,
on #1031 and `result_rmsd = rotation_method(p_coord, q_coord)` on oud #1034 differ
from the former.   It were helpful if you might confirm that my current selection of RMSD,
as the one for either method `--use-reflection` / inversion testing, or stereo conservative
method `--use-reflection-retain-stereo` matches my intention.  Could it be useful to "unify"
the RMSD such that eventually -- regardless if the alignment proceeds only by translation
and rotation, or considers even or potentially odd-numbered reflection -- were expressed
by one variable only?

[20190328-nbehrnd-documentation.zip](https://github.com/charnley/rmsd/files/3017803/20190328-nbehrnd-documentation.zip)
