### PR TITLE
Change 'print' by 'return' in main

### DIFF
--- a/rmsd/calculate_rmsd.py
+++ b/rmsd/calculate_rmsd.py
@@ -1877,7 +1877,8 @@ See https://github.com/charnley/rmsd for citation information
     return args
 
 
-def main(args: Optional[List[str]] = None) -> None:
+# def main(args: Optional[List[str]] = None) -> None:
+def main(args: Optional[List[str]] = None):
 
     # Parse arguments
     settings = parse_arguments(args)
@@ -2051,15 +2052,17 @@ https://github.com/charnley/rmsd for further examples.
 
         # done and done
         xyz = set_coordinates(q_all_atoms, q_coord, title=f"{settings.structure_b} - modified")
-        print(xyz)
+        return xyz
 
     else:
 
         if not result_rmsd:
             result_rmsd = rmsd_method(p_coord, q_coord)
 
-        print("{0}".format(result_rmsd))
+        # print("{0}".format(result_rmsd))
+        return result_rmsd 
 
 
 if __name__ == "__main__":
-    main()  # pragma: no cover
+    result = main()  # pragma: no cover
+    print(f'result {result}')

--- a/rmsd/calculate_rmsd.py
+++ b/rmsd/calculate_rmsd.py
@@ -1877,7 +1877,6 @@ See https://github.com/charnley/rmsd for citation information
     return args
 
 
-# def main(args: Optional[List[str]] = None) -> None:
 def main(args: Optional[List[str]] = None):
 
     # Parse arguments
@@ -2059,7 +2058,6 @@ https://github.com/charnley/rmsd for further examples.
         if not result_rmsd:
             result_rmsd = rmsd_method(p_coord, q_coord)
 
-        # print("{0}".format(result_rmsd))
         return result_rmsd 
 
 

--- a/rmsd/calculate_rmsd.py
+++ b/rmsd/calculate_rmsd.py
@@ -2065,4 +2065,4 @@ https://github.com/charnley/rmsd for further examples.
 
 if __name__ == "__main__":
     result = main()  # pragma: no cover
-    print(f'result {result}')
+    print(result)


### PR DESCRIPTION
Maybe this was unnecessary or there is a better way of doing it, but I use this module inside my scripts to calculate the rmsd between hundreds of pairs of molecules and I need to collected the rmsd values in a matrix.


So I changed the last two `print` in the main function by `return` so the results can be collected and used in those scripts when the main function is called as 'rmsd.main(file1,file2,--options...)' from the module.

e.g.
```
for i in range(n_files):
    for j in range(i+1,n_files):
        results[i,j] = rmsd.main([str(files[i]),str(files[j]),'-e'])
```
