### PR TITLE
fix reorder_inertia_hungarian uses wrong coordinates to determine COM

### DIFF
--- a/rmsd/calculate_rmsd.py
+++ b/rmsd/calculate_rmsd.py
@@ -1073,7 +1073,7 @@ def reorder_inertia_hungarian(
     q_coord = np.array(q_coord, copy=True)
 
     p_coord -= get_cm(p_atoms, p_coord)
-    q_coord -= get_cm(q_atoms, p_coord)
+    q_coord -= get_cm(q_atoms, q_coord)
 
     # Calculate inertia vectors for both structures
     inertia_p = get_inertia_tensor(p_atoms, p_coord)


### PR DESCRIPTION
Hello,

I discovered a bug in the `reorder_inertia_hungarian` function that causes an incorrect center of mass calculation for the second molecule (`q_coord`).

Currently, the function attempts to center `q_coord` using the coordinates of the first molecule (`p_coord`). This leads to improper alignment before the inertia tensors are calculated, which can result in a suboptimal atom reordering and an artificially high RMSD value.

The issue is located in `rmsd/calculate_rmsd.py`:

**The Buggy Line:**
```python
# ...
q_coord -= get_cm(q_atoms, p_coord)  # Incorrectly uses p_coord
# ...
```

**The Fix:**
The calculation should use the coordinates of the second molecule (`q_coord`) for its own centering operation:
```python
# ...
q_coord -= get_cm(q_atoms, q_coord)  # Correctly uses q_coord
# ...
```

This change ensures that both molecules are correctly centered at their respective centers of mass before the reordering algorithm proceeds.

I have not checked the entire codebase so there still might be some bugs of this kind.

Kind regards,
Ilias